### PR TITLE
Fixed make_parameters.jl bug

### DIFF
--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -191,7 +191,7 @@ function make_parameters(p::Dict{Symbol,Any})
   a[is_producer] = p[:a_producer]
 
   # Metabolic rate
-  body_size_relative = M ./ p[:m_producer]
+  body_size_relative = p[:bodymass] ./ p[:m_producer]
   body_size_scaled = body_size_relative.^-0.25
   x = (a ./ p[:a_producer]) .* body_size_scaled
 

--- a/test/make_parameters.jl
+++ b/test/make_parameters.jl
@@ -41,6 +41,11 @@ module TestMakeParameters
   p = model_parameters(correct_network, bodymass=right_bs)
   @test right_bs == p[:bodymass]
 
+  # Test that the metabolic rates are calculated from bodymass
+  p   = model_parameters(correct_network)
+  p_b = model_parameters(correct_network, bodymass = p[:bodymass) 
+  @test p[:x] == p_b[:x]
+    
   # Test that there is an exception if the wrong productivity is used
   wrong_pr = :global
   @test_throws ErrorException model_parameters(correct_network, productivity=wrong_pr)

--- a/test/make_parameters.jl
+++ b/test/make_parameters.jl
@@ -43,7 +43,7 @@ module TestMakeParameters
 
   # Test that the metabolic rates are calculated from bodymass
   p   = model_parameters(correct_network)
-  p_b = model_parameters(correct_network, bodymass = p[:bodymass) 
+  p_b = model_parameters(correct_network, bodymass = p[:bodymass]) 
   @test p[:x] == p_b[:x]
     
   # Test that there is an exception if the wrong productivity is used


### PR DESCRIPTION
There was a bug where providing a biomass index would result in metabolic rates ( `p[:x]` ) being equal to `inf` #15 


**Summary of changes:**

1. changed the source of biomasses for the calculation of metabolic rates

