### PR TITLE
Gilljam and ADBM rewiring

### DIFF
--- a/src/BioEnergeticFoodWebs.jl
+++ b/src/BioEnergeticFoodWebs.jl
@@ -4,9 +4,11 @@ using Distributions
 using DifferentialEquations
 using JSON
 using JLD
+using StatsBase
 
 export trophic_rank,
   model_parameters,
+  rewire_parameters,
   simulate,
   nichemodel,
   population_stability,
@@ -24,5 +26,13 @@ include(joinpath(".", "make_parameters.jl"))
 include(joinpath(".", "simulate.jl"))
 include(joinpath(".", "random.jl"))
 include(joinpath(".", "measures.jl"))
+
+include(joinpath(".", "rewiring/ADBM.jl"))
+include(joinpath(".", "rewiring/GilljamRewire.jl"))
+include(joinpath(".", "rewiring/parameters/checkParameters.jl"))
+include(joinpath(".", "rewiring/parameters/makeParameters.jl"))
+include(joinpath(".", "rewiring/parameters/updateParameters.jl"))
+
+
 
 end

--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -32,13 +32,13 @@ This function is the one wrapped by the various integration routines. Based on a
 timepoint `t`, an array of biomasses `biomass`, and a series of simulation
 parameters `p`, it will return `dB/dt` for every species.
 """
-function dBdt(t, biomass, p::Dict{Symbol,Any})
+function dBdt(t, biomass, p::Dict{Symbol,Any}, p_r::Dict{Symbol,Any})
 
   S = size(p[:A], 1)
   derivative = zeros(Float64, length(biomass))
 
   # Total available biomass
-  bm_matrix = p[:w]*biomass'.*p[:A]
+  bm_matrix = p[:w] .* ( biomass'.*p[:A]) .* p_r[:costMat]
   food_available = vec(sum(bm_matrix, 2))
 
   f_den = p[:Γh]*(1.0+p[:c].*biomass).+food_available

--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -146,7 +146,7 @@ function make_parameters(p::Dict{Symbol,Any})
   S = size(A)[1]
   F = zeros(Float64, size(A))
   efficiency = zeros(Float64, size(A))
-  w = zeros(Float64, S)
+  w = zeros(Float64, size(A))
   M = zeros(Float64, S)
   a = zeros(Float64, S)
   x = zeros(Float64, S)
@@ -173,9 +173,9 @@ function make_parameters(p::Dict{Symbol,Any})
 
   # Measure generality and extract the vector of 1/n
   generality = float(vec(sum(A, 2)))
-  for i in eachindex(generality)
-    if generality[i] > 0.0
-      w[i] = 1.0 / generality[i]
+  for i in 1:size(w,1), j in 1:size(w,2)
+    if A[i,j] == 1
+      w[i,j] = 1.0 / generality[i]
     end
   end
 

--- a/src/rewiring/ADBM.jl
+++ b/src/rewiring/ADBM.jl
@@ -1,0 +1,93 @@
+"""
+
+**ADBM Terms**
+
+This function takes the parameters for the ADBM model and returns
+the final terms used to determine feeding patterns. It is used internally by  ADBM().
+"""
+
+function getADBM_Terms(S::Int64,p::Dict{Symbol,Any},biomass::Vector{Float64},p_r::Dict{Symbol,Any})
+  E = p_r[:e] .* p[:bodymass]
+  if p_r[:Nmethod] == :original
+    N = p_r[:n] .* (p[:bodymass] .^ p_r[:ni])
+  elseif p_r[:Nmethod] == :biomass
+    N = biomass
+  end
+  A = p_r[:a] * (p[:bodymass].^p_r[:aj]) * (p[:bodymass].^p_r[:ai])' # a * pred * prey
+  for i = 1:S #for each prey
+    A[:,i] = A[:,i] .* N[i]
+  end
+  λ = A
+  if p_r[:Hmethod] == :ratio
+    H = zeros(Float64,(S,S))
+    ratios = (p[:bodymass] ./ p[:bodymass]')' #PREDS IN ROWS : PREY IN COLS
+    for i = 1:S , j = 1:S
+      if ratios[j,i] < p_r[:b]
+      H[j,i] =  p_r[:h] / (p_r[:b] - ratios[j,i])
+      else
+      H[j,i] = Inf
+      end
+    end
+  elseif p_r[:Hmethod] == :power
+    H = p_r[:h] * (p[:bodymass].^p_r[:hj]) * (p[:bodymass].^p_r[:hi])' # h * pred * prey
+  end
+
+  adbmTerms = Dict{Symbol,Any}(
+  :E => E,
+  :λ => λ,
+  :H => H)
+
+  return(adbmTerms)
+end
+
+"""
+
+**ADBM Feeding Links**
+
+This function takes the terms calculated by getADBM_Terms() and uses them to determine the feeding
+links of species j. Used internally by ADBM().
+"""
+
+function getFeedingLinks(S::Int64,E::Vector{Float64}, λ::Array{Float64}, H::Array{Float64},j)
+  profit = E ./ H[j,:]
+  profs = sortperm(profit,rev = true)
+  profitSort = profit[profs]
+  λSort = λ[j,profs]
+  HSort = H[j,profs]
+  ESort = E[profs]
+  cumulativeProfit = cumsum(ESort .* λSort) ./ (1 + cumsum(λSort .* HSort))
+  if all(0 .== cumulativeProfit)
+  feeding = []
+  else
+  feeding = profs[1:maximum(find(cumulativeProfit .== maximum(cumulativeProfit)))]
+  end
+
+  #cumulativeProfit[end] = NaN
+  #feeding = profs[(append!([true],cumulativeProfit[1:end-1] .< profitSort[2:end]))]
+  return(feeding)
+end
+
+
+"""
+**ADBM Web**
+
+This function returns the food web based on the ADBM model of Petchey et al. 2008. The function
+takes the paramteres created by rewire_parameters() and uses getADBM_Terms() and getFeedingLinks() to
+detemine the web structure. This function is called using the callback to include rewiring into biomass simulations.
+"""
+
+
+function ADBM(S::Int64,p::Dict{Symbol,Any},biomass::Vector{Float64},p_r::Dict{Symbol,Any})
+  adbmMAT = zeros(Int64,(S,S))
+  adbmTerms = getADBM_Terms(S,p,biomass,p_r)
+  E = adbmTerms[:E]
+  λ = adbmTerms[:λ]
+  H = adbmTerms[:H]
+  for j = 1:S
+    if !p[:is_producer][j]
+      feeding = getFeedingLinks(S,E,λ,H,j)
+      adbmMAT[j,feeding] = 1
+    end
+  end
+  return(adbmMAT)
+end

--- a/src/rewiring/GilljamRewire.jl
+++ b/src/rewiring/GilljamRewire.jl
@@ -1,0 +1,33 @@
+function Gilljam(S::Int64,p::Dict{Symbol,Any},biomass::Vector{Float64},p_r::Dict{Symbol,Any})
+  #create matrix to work on
+  preferenceMat = deepcopy(p[:A])
+
+  #add extinction to the new matrix
+  preferenceMat[:,p_r[:extinctions]] = 0
+  preferenceMat[p_r[:extinctions],:] = 0
+
+  #where do new links need to be formed?
+  newLinks = trues(3,S)
+  #Sp that have no prey
+  newLinks[1,:] = (sum(preferenceMat,2) .== 0)
+  #Sp that are not producers
+  newLinks[2,:] = !p[:is_producer]
+  #Sp that are extinction
+  newLinks[3,p_r[:extinctions]] = false
+  #rows where all conditions are met
+  newLinks = find(mapslices(all,newLinks,1))
+
+  if !isempty(newLinks)
+    #code adds new links based on jaccard similariy
+    for i in newLinks #for each Sp that needs a new link
+      similarities = p_r[:similarity][newLinks][1] #get the similarity ranks
+      deleteat!(similarities,findin(similarities,p_r[:extinctions])) # remove extinctions
+      deleteat!(similarities,findin(similarities,find(sum(preferenceMat,2).==0,)))#remove Sp without prey
+
+      newLink = sample(find(preferenceMat[similarities[end],:])) #choose link to make
+      preferenceMat[i,newLink] = 1 #add  link to the new predation matrix
+      p_r[:costMat][i,newLink] = p_r[:cost]
+    end
+  end
+  return(preferenceMat,p_r)
+end

--- a/src/rewiring/parameters/checkParameters.jl
+++ b/src/rewiring/parameters/checkParameters.jl
@@ -1,0 +1,40 @@
+"""
+**Check Rewiring parameters**
+
+This function will check that all the required rewiring parameters are present
+"""
+
+function check_rewiring_parameters(rewireP,rewireMethod)
+  if rewireMethod == :ADBM
+    required_keys = [
+    :e,
+    :a,
+    :ai,
+    :aj,
+    :b,
+    :h,
+    :hi,
+    :hj,
+    :n,
+    :ni,
+    :Nmethod,
+    :Hmethod,
+    :rewireMethod,
+    :costMat]
+  elseif rewireMethod == :Gilljam
+    required_keys = [
+    :rewireMethod,
+    :similarity,
+    :specialistPrefMag,
+    :extinctions,
+    :preferenceMethod,
+    :cost,
+    :costMat,
+    :specialistPref]
+  end
+
+  for k in required_keys
+    @assert get(rewireP, k, nothing) != nothing
+  end
+
+end

--- a/src/rewiring/parameters/makeParameters.jl
+++ b/src/rewiring/parameters/makeParameters.jl
@@ -1,0 +1,121 @@
+"""
+
+**Make Rewiring parameters**
+
+This function serves as a wrapper to generate the parameters for the various rewiring mechanisms.
+
+The only requred arguments are the rewireMethod and A (array) if the method from Gilljam et al. (2015) is used.
+"""
+function rewire_parameters(rewireMethod::Symbol ; e::Float64 = 1.0, a::Float64 = 0.0189, ai::Float64 = -0.491, aj::Float64 = -0.465,
+  b::Float64 = 0.401, h::Float64 = 1.0, hi::Float64 = 1.0, hj::Float64 = 1.0, n::Float64 = 1.0, ni::Float64= -0.75,
+  Hmethod::Symbol = :ratio, Nmethod::Symbol = :original, cost = 0.0::Float64,specialistPrefMag::Float64 = 0.9,preferenceMethod::Symbol = :generalist,
+  A = 0)
+
+  #check rewire method
+  if rewireMethod ∉ [:ADBM,:none,:Gilljam]
+    error("Invalid value for rewiremethod -- must be :ADBM, :none or :Gilljam")
+  end
+
+  if typeof(A) != Matrix{Int64}
+    error("No Array Supplied")
+  end
+
+  #ADBM parameters
+  if rewireMethod == :ADBM
+    rewireP = adbm_parameters(e,a,ai,aj,b,h,hi,hj,n,ni)
+    #check Hmethod
+    if Hmethod ∈ [:ratio, :power]
+      rewireP[:Hmethod] = Hmethod
+    else
+      error("Invalid value for Hmethod -- must be :ratio or :power")
+    end
+    # check Nmethod
+    if Nmethod ∈ [:original, :biomass]
+      rewireP[:Nmethod] = Nmethod
+    else
+      error("Invalid value for Nmethod -- must be :original or :biomass")
+    end
+    #add empty cost matrix
+    S = size(A,2)
+    rewireP[:costMat] = ones(Float64,(S,S))
+
+  elseif rewireMethod == :Gilljam
+    #preference parameters
+    rewireP = preference_parameters(cost,specialistPrefMag,A)
+    #check preferenceMethod
+    if preferenceMethod ∈ [:generalist, :specialist]
+      rewireP[:preferenceMethod] = preferenceMethod
+      rewireP[:specialistPref] = getSpeciaistPref(rewireP,A)
+    else
+      error("Invalid value for preferenceMethod -- must be :generalist or :specialist")
+    end
+  end
+  rewireP[:rewireMethod] = rewireMethod
+  check_rewiring_parameters(rewireP,rewireMethod)
+  return(rewireP)
+end
+
+
+
+function adbm_parameters(e::Float64,a::Float64,ai::Float64,aj::Float64,
+  b::Float64,h::Float64,hi::Float64,hj::Float64,n::Float64,ni::Float64)
+
+  adbmParameters = Dict{Symbol,Any}(:e  => e,
+                                    :a  => a,
+                                    :ai => ai,
+                                    :aj => aj,
+                                    :b  => b,
+                                    :h  => h,
+                                    :hi => hi,
+                                    :hj => hj,
+                                    :n  => n,
+                                    :ni => ni)
+  return(adbmParameters)
+end
+
+function preference_parameters(cost::Float64,specialistPrefMag::Float64,A::Array{Int64})
+  #Work out the jaccard similarity
+  S = size(A,1)
+  similarity = zeros(Float64,(S,S))
+  for i = 1:S, j = 1:S
+    if i == j
+    similarity[i,j] = 0
+    else
+      X = find(A[i,:])
+      Y = find(A[j,:])
+      if length(X) == 0 && length(Y) == 0
+        similarity[i,j] = 0
+      else
+        similarity[i,j] = size(intersect(X,Y),1) / size(union(X,Y),1)
+      end
+    end
+  end
+
+  similarityIndexes = Vector{Vector{Int}}(S)
+  #convert to indexes
+  for i = 1:S
+    similarityIndexes[i] = sortperm(similarity[i,:])
+  end
+
+  preferenceParameters = Dict{Symbol,Any}(:similarity => similarityIndexes,
+                                          :cost       => cost,
+                                          :specialistPrefMag => specialistPrefMag,
+                                          :extinctions => Array{Int,1}(),
+                                          :costMat => ones(Float64,(S,S)))
+  return(preferenceParameters)
+end
+
+
+
+function getSpeciaistPref(rewireP::Dict{Symbol,Any},A)
+  specials = zeros(Int64,size(A,1))
+  if rewireP[:preferenceMethod] == :specialist
+    for pred = 1:size(A,2)
+        prey = find(A[pred,:])
+        if length(prey) > 0
+          specials[pred] = sample(prey,1)[1]
+        end
+    end
+  end
+  return(specials)
+end

--- a/src/rewiring/parameters/updateParameters.jl
+++ b/src/rewiring/parameters/updateParameters.jl
@@ -1,0 +1,138 @@
+function update_params(p::Dict{Symbol,Any},S::Int64,p_r::Dict{Symbol,Any},biomass)
+  if p_r[:rewireMethod] == :ADBM
+    #assign new array
+    p[:A] = BioEnergeticFoodWebs.ADBM(S,p,biomass,p_r)
+
+    #update the parameters
+    p = getHerbivores(p,S) #
+    p = getW_ADBM(p,S) #
+    p = getEfficency(p,S)
+
+  elseif p_r[:rewireMethod] == :Gilljam
+    #add extinction
+    workingBiomass = deepcopy(biomass)
+    deleteat!(workingBiomass,p_r[:extinctions])
+    append!(p_r[:extinctions],findin(biomass,findmin(workingBiomass)[1]))
+    sort!(p_r[:extinctions])
+
+    #assign new array and update costs
+    p[:A] , p_r = BioEnergeticFoodWebs.Gilljam(S,p,biomass,p_r)
+
+    #update rewiring parameters
+    if p_r[:preferenceMethod] == :specialist
+      p_r = BioEnergeticFoodWebs.updateSpecialistPref(p,p_r,S)
+    end
+
+    #update parameters
+    p = getHerbivores(p,S)
+    p = getW_preference(p,p_r,S)
+    p[:w][find(p[:w] .== Inf)] = 1
+    p = getEfficency(p,S)
+
+  end
+return((p,p_r))
+end
+
+function getHerbivores(p::Dict{Symbol,Any},S::Int64)
+  # Identify herbivores
+  # Herbivores consume producers
+  for consumer in 1:S
+    if !p[:is_producer][consumer]
+      for resource in 1:S
+        if p[:is_producer][resource]
+          if p[:A][consumer, resource] == 1
+            p[:is_herbivore][consumer] = true
+          end
+        end
+      end
+    end
+  end
+  return(p)
+end
+
+function getEfficency(p::Dict{Symbol,Any},S::Int64)
+  # Efficiency matrix
+  for consumer in 1:S
+    for resource in 1:S
+      if p[:A][consumer, resource] == 1
+        if p[:is_producer][resource]
+          p[:efficiency][consumer, resource] = p[:e_herbivore]
+        else
+          p[:efficiency][consumer, resource] = p[:e_carnivore]
+        end
+      else
+        p[:efficiency][consumer, resource] = 0.0
+      end
+    end
+  end
+  return(p)
+end
+
+function getW_ADBM(p::Dict{Symbol,Any},S::Int64)
+  generality = float(vec(sum(p[:A], 2)))
+  for i in eachindex(generality)
+    if generality[i] > 0.0
+      for j = 1:S
+        if p[:A][i,j] == 1
+          p[:w][i,j] = 1.0 / generality[i]
+        end
+      end
+    end
+  end
+  return(p)
+end
+
+function getW_preference(p::Dict{Symbol,Any},p_r::Dict{Symbol,Any},S::Int64)
+  p[:w] = zeros(Float64,(S,S))
+  generality = float(vec(sum(p[:A], 2)))
+  if p_r[:preferenceMethod] == :generalist
+    for i in eachindex(generality)
+      if generality[i] > 0.0
+        for j = 1:S
+          if p[:A][i,j] == 1
+            p[:w][i,j] = 1.0 / generality[i]
+          end
+        end
+      end
+    end
+  elseif p_r[:preferenceMethod] == :specialist
+    for i in eachindex(generality)
+      if generality[i] > 0.0
+        for j = 1:S
+          if p[:A][i,j] == 1
+            if p_r[:specialistPref][i] == j
+              if generality[i] > 1
+                p[:w][i,j] = p_r[:specialistPrefMag]
+              else
+                p[:w][i,j] = 1.0
+              end
+            else
+              p[:w][i,j] = (1 - p_r[:specialistPrefMag])/(generality[i]-1)
+            end
+          end
+        end
+      end
+    end
+  end
+  return(p)
+end
+
+function updateSpecialistPref(p::Dict{Symbol,Any},p_r::Dict{Symbol,Any},S::Int64)
+  #find those that have lost thier specialistPref and are not extinct
+  lost = falses(S)
+  for i = 1:S
+    if !p[:is_producer][i] && !in(i,p_r[:extinctions])
+      if p[:A][i,p_r[:specialistPref][i]] == 0
+        #assign new random species from diet
+        p_r[:specialistPref][i] = sample(find(p[:A][i,:]))
+      end
+    else
+      p_r[:specialistPref][i] = 0
+    end
+  end
+  return(p_r)
+end
+
+function updateCost(p::Dict{Symbol,Any},p_r::Dict{Symbol,Any},S::Int64)
+
+end

--- a/test/simulate.jl
+++ b/test/simulate.jl
@@ -33,8 +33,8 @@ module TestSimulateSanityCheck
   p = free_producers |> model_parameters
   n = rand(4)
 
-  s = simulate(p, n, start=0, stop=15, use=:stiff)
-  @test_approx_eq_eps s[:B][16,4] p[:K] 0.001
+  s = simulate(p, n, start=0, stop=25, use=:stiff)
+  @test_approx_eq_eps s[:B][26,4] p[:K] 0.002
 
   # Using system-wide regulation, producers with no consumption reach K / n
   A = zeros(Int64, (4, 4))


### PR DESCRIPTION
Addresses issue #29 .

This is the code I have for rewiring so far. I followed the basic approach used in the package with all rewiring parameters being stored in a dictionary (`p_r`) which is created using the single `rewire_parameters()`. This is passed on to the `simulate()` function along with the model parameters (`p`)

I've used the callback functionality of the DifferentialEquations package which allows code to be run when certain criteria are fulfilled. In this case when any of the biomasses reach zero code is run to update both `p` and `p_r`. This updates the interaction matrix according to the method chosen as well as some other parameters. At the moment the code outputs the time at which extinctions occur to help with debugging and it appears to be working for both the ADBM and Gilljam Methods.

# Summary of changes:

1. Requires StatsBase
2. Added costMat to the `dBdt()` function which is stored in `p_r`. This allows a set cost to be added to new interactions as in Gilljam's method.
3. Changed `:w` in `p` to be a 2D matrix to allow for differential preferences as in Gilljam's method.
4. `simulate()` now takes `p_r` as an argument and has the callback functions added.
5. Added rewiring code contained in the folder Rewiring.
   The parameter folder contains code that generates, checks and updates both `p` and `p_r`
   The Gilljam and ADBM files contain the code to generate the interaction matricies.

# Potential Problems

As it stands the problem of how extinctions are defined seems quite important. In `Dbdt()` extinctions are defined as when `Biomass < eps(0.0)` whereas the rewiring code is being run when the biomasses cross into the negative. There is also alot of simplification and refactoring that could be done, especially potentially condensing `p` and `p_r` into a single object.