### PR TITLE
fix callback condition

### DIFF
--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -52,7 +52,7 @@ function simulate(p, biomass; start::Int64=0, stop::Int64=500, use::Symbol=:nons
     # if t == Int(round(t))
     #   println(minimum(y[.!isext]))
     # end
-    minimum(y[.!isext])
+    !all(isext) ? minimum(y[.!isext]) : 1
   end
 
   function affect!(integrator)


### PR DESCRIPTION
To the rewiring branch. Changes the condition so that it will not error when all extinctions have occured.