### PR TITLE
Fix diffeq setup

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
 Distributions
-DifferentialEquations 1.5.0
+OrdinaryDiffEq
 JSON
 JLD

--- a/src/BioEnergeticFoodWebs.jl
+++ b/src/BioEnergeticFoodWebs.jl
@@ -1,7 +1,7 @@
 module BioEnergeticFoodWebs
 
 using Distributions
-using DifferentialEquations
+using OrdinaryDiffEq
 using JSON
 using JLD
 

--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -32,10 +32,9 @@ This function is the one wrapped by the various integration routines. Based on a
 timepoint `t`, an array of biomasses `biomass`, and a series of simulation
 parameters `p`, it will return `dB/dt` for every species.
 """
-function dBdt(t, biomass, p::Dict{Symbol,Any})
+function dBdt(t, biomass, p::Dict{Symbol,Any}, derivative)
 
   S = size(p[:A], 1)
-  derivative = zeros(Float64, length(biomass))
 
   # Total available biomass
   bm_matrix = p[:w]*biomass'.*p[:A]
@@ -52,7 +51,7 @@ function dBdt(t, biomass, p::Dict{Symbol,Any})
   gain = vec(sum(transfered, 2))
   loss = vec(sum(consumed, 1))
 
-  growth = zeros(Float64, S)
+  growth = zeros(eltype(biomass), S)
 
   for i in eachindex(biomass)
     if p[:is_producer][i]

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -41,11 +41,18 @@ function simulate(p, biomass; start::Int64=0, stop::Int64=500, use::Symbol=:stif
   t_keep = collect(start:1.0:stop)
 
   # Pre-assign function
-  f(t, y) = dBdt(t, y, p)
+  f(t, y, dy) = dBdt(t, y, p, dy)
 
   # Perform the actual integration
   prob = ODEProblem(f, biomass, t)
-  sol = solve(prob, saveat=t_keep, dense=false, save_timeseries=false, alg_hints=[use])
+
+  if use == :stiff
+      alg = Rodas4()
+  else
+      alg = Tsit5()
+  end
+
+  sol = solve(prob, alg, saveat=t_keep, dense=false, save_timeseries=false)
 
   output = Dict{Symbol,Any}(
   :p => p,

--- a/test/simulate.jl
+++ b/test/simulate.jl
@@ -17,7 +17,8 @@ module TestSimulateHandChecked
   A = [0 1 0; 0 0 0; 0 1 0]
   p = model_parameters(A)
   b0 = vec([0.2 0.4 0.1])
-  der = BioEnergeticFoodWebs.dBdt(0.0, b0, p)
+  der = similar(b0)
+  BioEnergeticFoodWebs.dBdt(0.0, b0, p, der)
   # 0.1604888888888889,-0.4,0.08024444444444445
   @test_approx_eq_eps der[1] 0.160 0.01
   @test_approx_eq_eps der[2] -0.4 0.01


### PR DESCRIPTION
This PR does a few things:

- It replaces the DifferentialEquations.jl dependency via OrdinaryDiffEq.jl. This makes the installation a lot smaller. You can grab other pieces similarly as needed. For example, If you want to also use the callbacks from the callback library (positivity callback), you can just add DiffEqCallbacks.jl and it'll be there, without the rest of the machinery.
- To handle the defaults, it just hardcodes the algorithms for stiff and non-stiff now. 
- The typing in dBdt is now fixed to work with autodifferentiation. 
- dBdt now uses the inplace form which should reduce the number of allocations.