### PR TITLE
Update DiffEq to v4.0.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.5
 Distributions
-OrdinaryDiffEq
-Sundials
+OrdinaryDiffEq 3.0.0
+Sundials 1.1.0
 DiffEqCallbacks
 JSON
 JLD

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,7 @@
 julia 0.5
 Distributions
-DifferentialEquations 1.5.0
+OrdinaryDiffEq
+Sundials
+DiffEqCallbacks
 JSON
 JLD

--- a/src/BioEnergeticFoodWebs.jl
+++ b/src/BioEnergeticFoodWebs.jl
@@ -1,7 +1,7 @@
 module BioEnergeticFoodWebs
 
 using Distributions
-using DifferentialEquations
+using OrdinaryDiffEq, Sundials, DiffEqCallbacks
 using JSON
 using JLD
 

--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -32,7 +32,7 @@ This function is the one wrapped by the various integration routines. Based on a
 timepoint `t`, an array of biomasses `biomass`, and a series of simulation
 parameters `p`, it will return `dB/dt` for every species.
 """
-function dBdt(t, biomass, p::Dict{Symbol,Any})
+function dBdt(biomass, p::Dict{Symbol,Any}, t)
 
   S = size(p[:A], 1)
   derivative = zeros(Float64, length(biomass))

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -40,12 +40,16 @@ function simulate(p, biomass; start::Int64=0, stop::Int64=500, use::Symbol=:stif
   t = (float(start), float(stop))
   t_keep = collect(start:1.0:stop)
 
-  # Pre-assign function
-  f(t, y) = dBdt(t, y, p)
-
   # Perform the actual integration
-  prob = ODEProblem(f, biomass, t)
-  sol = solve(prob, saveat=t_keep, dense=false, save_timeseries=false, alg_hints=[use])
+  prob = ODEProblem(dBdt, biomass, t, p)
+
+  if use == :stiff
+      alg = CVODE_BDF()
+  else
+      alg = Tsit5()
+  end
+
+  sol = solve(prob, alg, saveat=t_keep, dense=false, save_timeseries=false)
 
   output = Dict{Symbol,Any}(
   :p => p,

--- a/test/simulate.jl
+++ b/test/simulate.jl
@@ -17,7 +17,7 @@ module TestSimulateHandChecked
   A = [0 1 0; 0 0 0; 0 1 0]
   p = model_parameters(A)
   b0 = vec([0.2 0.4 0.1])
-  der = BioEnergeticFoodWebs.dBdt(0.0, b0, p)
+  der = BioEnergeticFoodWebs.dBdt(b0, p, 0.0)
   # 0.1604888888888889,-0.4,0.08024444444444445
   @test_approx_eq_eps der[1] 0.160 0.01
   @test_approx_eq_eps der[2] -0.4 0.01


### PR DESCRIPTION
DifferentialEquations v4.0.0 had a syntax change. This PR updates the internal integrator calls to that. Also, this uses the solvers directly to get rid of the larger DifferentialEquations.jl dependency and replaces it with the OrdinaryDiffEq.jl, Sundials.jl, and DiffEqCallbacks.jl (for the PositiveDomain() callback).