### PR TITLE
:ambulance: CI fails when pulling v1.0.0 on METADATA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: julia
 sudo: required
 os:
   - linux
-matrix:
-  allow_failures:
-    - julia: 0.7
+# matrix:
+#   allow_failures:
+#     - julia: 0.7
 julia:
   - 0.7
   - 1.0
@@ -21,7 +21,7 @@ before_script:
 after_success:
   - julia -e 'import Pkg; cd(Pkg.dir("BioEnergeticFoodWebs")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(Codecov.process_folder())'
   - julia -e 'import Pkg; Pkg.add("Documenter")'
-  - julia -e 'import Pkg; import Documenter; ENV["DOCUMENTER_DEBUG"] = "true"; import BioEnergeticFoodWebs; include(joinpath("docs", "make.jl"))'
+  - julia -e 'import Pkg; import Documenter; import BioEnergeticFoodWebs; include(joinpath("docs", "make.jl"))'
   #- julia -e 'using Pkg; ps=Pkg.PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps); include(joinpath("docs", "make.jl"))'
   #- julia -e 'import Pkg; cd(Pkg.dir("BioEnergeticFoodWebs")); include(joinpath("docs", "make.jl"))'
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,9 +1,7 @@
-julia 1.0
+julia 0.7
 Distributions
 OrdinaryDiffEq
 DiffEqCallbacks
 JSON
 JLD
 StatsBase
-Statistics
-LinearAlgebra


### PR DESCRIPTION
(From Job Log) 

Tagged version 1.0 of BioEnergeticFoodWebs lists the standard library module Statistics in its REQUIRE file. Stdlibs should not be listed in REQUIRE, only in Project.toml.
Remove Statistics from REQUIRE and retag.

