### PR TITLE
Fix extinction tracking

### DIFF
--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -220,6 +220,9 @@ function model_parameters(A;
 
  if rewire_method ∈ [:stan, :none, :ADBM, :Gilljam]
     parameters[:rewire_method] = rewire_method
+    parameters[:extinctions] = []
+    parameters[:extinctionstime] = []
+    parameters[:tmpA] = []
  else
     error("Invalid method for rewiring -- must be :stan, :ADBM, :Gilljam or :none")
  end

--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -231,8 +231,8 @@ function model_parameters(A;
      adbm_parameters(parameters, e, a_adbm, ai, aj, b, h_adbm, hi, hj, n, ni, Hmethod, Nmethod)
  elseif rewire_method == :Gilljam
      gilljam_parameters(parameters, cost, specialistPrefMag, preferenceMethod)
- elseif rewire_method == :stan
-     parameters[:extinctions] = Array{Int,1}()
+ #elseif rewire_method == :stan
+     #parameters[:extinctions] = Array{Int,1}()
  end
  check_rewiring_parameters(parameters, parameters[:rewire_method])
 
@@ -384,7 +384,7 @@ function preference_parameters(cost, specialistPrefMag, A, preferenceMethod)
   preference_parameters = Dict{Symbol,Any}(:similarity => similarity_indexes,
                                           :cost       => cost,
                                           :specialistPrefMag => specialistPrefMag,
-                                          :extinctions => Array{Int,1}(),
+                                          #:extinctions => Array{Int,1}(),
                                           :costMat => ones(Float64,(S,S)),
                                           :preferenceMethod => preferenceMethod)
   return(preference_parameters)
@@ -402,7 +402,7 @@ function gilljam_parameters(parameters, cost, specialistPrefMag, preferenceMetho
   end
   parameters[:similarity] = rewireP[:similarity]
   parameters[:specialistPrefMag] = rewireP[:specialistPrefMag]
-  parameters[:extinctions] = rewireP[:extinctions]
+  #parameters[:extinctions] = rewireP[:extinctions]
   parameters[:preferenceMethod] = rewireP[:preferenceMethod]
   parameters[:cost] = rewireP[:cost]
   parameters[:costMat] = rewireP[:costMat]

--- a/src/rewiring/ADBM.jl
+++ b/src/rewiring/ADBM.jl
@@ -48,7 +48,7 @@ function get_feeding_links(S::Int64,E::Vector{Float64}, λ::Array{Float64},
   profit = E ./ H[j,:]
   # Setting profit of species with zero biomass  to -1.0
   # This prevents them being included in the profitSort
-  profit[biomass .== 0.0] .= -1.0
+  profit[vec(biomass .== 0.0)] .= -1.0
 
   profs = sortperm(profit,rev = true)
 

--- a/src/rewiring/parameters/updateParameters.jl
+++ b/src/rewiring/parameters/updateParameters.jl
@@ -3,11 +3,13 @@ function update_rewiring_parameters(parameters::Dict{Symbol,Any}, biomass, t)
   append!(parameters[:tmpA], [parameters[:A]])
 
   if parameters[:rewire_method] == :ADBM
-    #add extinction
-    workingBiomass = deepcopy(biomass)
-    deleteat!(workingBiomass,parameters[:extinctions])
-    append!(parameters[:extinctions],findmin(workingBiomass)[2])
-    append!(parameters[:extinctionstime], (t, findmin(workingBiomass)[2]))
+    extinct = findall(biomass .< 100*eps())
+    for i in extinct
+      if i ∉ parameters[:extinctions]
+        append!(parameters[:extinctions], i) ;
+        append!(parameters[:extinctionstime], [(t, i)])
+      end
+    end
     sort!(parameters[:extinctions])
 
     #assign new array
@@ -20,10 +22,13 @@ function update_rewiring_parameters(parameters::Dict{Symbol,Any}, biomass, t)
 
   elseif parameters[:rewire_method] == :Gilljam
     #add extinction
-    workingBiomass = deepcopy(biomass)
-    deleteat!(workingBiomass,parameters[:extinctions])
-    append!(parameters[:extinctions],findmin(workingBiomass)[2])
-    append!(parameters[:extinctionstime], (t, findmin(workingBiomass)[2]))
+    extinct = findall(biomass .< 100*eps())
+    for i in extinct
+      if i ∉ parameters[:extinctions]
+        append!(parameters[:extinctions], i) ;
+        append!(parameters[:extinctionstime], [(t, i)])
+      end
+    end
     sort!(parameters[:extinctions])
 
     #assign new array and update costs
@@ -42,10 +47,13 @@ function update_rewiring_parameters(parameters::Dict{Symbol,Any}, biomass, t)
 
   elseif parameters[:rewire_method] == :stan
     #add extinction
-    workingBiomass = deepcopy(biomass)
-    deleteat!(workingBiomass,parameters[:extinctions])
-    id_Ɛ = findmin(workingBiomass)[2]
-    append!(parameters[:extinctions], id_Ɛ)
+    extinct = findall(biomass .< 100*eps())
+    for i in extinct
+      if i ∉ parameters[:extinctions]
+        append!(parameters[:extinctions], i) ;
+        append!(parameters[:extinctionstime], [(t, i)])
+      end
+    end
     sort!(parameters[:extinctions])
 
     parameters[:A] = Staniczenko_rewire(parameters)

--- a/src/rewiring/parameters/updateParameters.jl
+++ b/src/rewiring/parameters/updateParameters.jl
@@ -1,6 +1,5 @@
 function update_rewiring_parameters(parameters::Dict{Symbol,Any}, biomass, t)
   S = size(parameters[:A], 1)
-  append!(parameters[:tmpA], [parameters[:A]])
 
   if parameters[:rewire_method] == :ADBM
     extinct = findall(biomass .< 100*eps())
@@ -8,6 +7,7 @@ function update_rewiring_parameters(parameters::Dict{Symbol,Any}, biomass, t)
       if i ∉ parameters[:extinctions]
         append!(parameters[:extinctions], i) ;
         append!(parameters[:extinctionstime], [(t, i)])
+        append!(parameters[:tmpA], [parameters[:A]])
       end
     end
     sort!(parameters[:extinctions])
@@ -27,6 +27,7 @@ function update_rewiring_parameters(parameters::Dict{Symbol,Any}, biomass, t)
       if i ∉ parameters[:extinctions]
         append!(parameters[:extinctions], i) ;
         append!(parameters[:extinctionstime], [(t, i)])
+        append!(parameters[:tmpA], [parameters[:A]])
       end
     end
     sort!(parameters[:extinctions])
@@ -52,6 +53,7 @@ function update_rewiring_parameters(parameters::Dict{Symbol,Any}, biomass, t)
       if i ∉ parameters[:extinctions]
         append!(parameters[:extinctions], i) ;
         append!(parameters[:extinctionstime], [(t, i)])
+        append!(parameters[:tmpA], [parameters[:A]])
       end
     end
     sort!(parameters[:extinctions])

--- a/src/rewiring/parameters/updateParameters.jl
+++ b/src/rewiring/parameters/updateParameters.jl
@@ -1,7 +1,15 @@
-function update_rewiring_parameters(parameters::Dict{Symbol,Any}, biomass)
+function update_rewiring_parameters(parameters::Dict{Symbol,Any}, biomass, t)
   S = size(parameters[:A], 1)
+  append!(parameters[:tmpA], [parameters[:A]])
 
   if parameters[:rewire_method] == :ADBM
+    #add extinction
+    workingBiomass = deepcopy(biomass)
+    deleteat!(workingBiomass,parameters[:extinctions])
+    append!(parameters[:extinctions],findmin(workingBiomass)[2])
+    append!(parameters[:extinctionstime], (t, findmin(workingBiomass)[2]))
+    sort!(parameters[:extinctions])
+
     #assign new array
     parameters[:A] = ADBM(S,parameters,biomass)
 
@@ -15,6 +23,7 @@ function update_rewiring_parameters(parameters::Dict{Symbol,Any}, biomass)
     workingBiomass = deepcopy(biomass)
     deleteat!(workingBiomass,parameters[:extinctions])
     append!(parameters[:extinctions],findmin(workingBiomass)[2])
+    append!(parameters[:extinctionstime], (t, findmin(workingBiomass)[2]))
     sort!(parameters[:extinctions])
 
     #assign new array and update costs

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -55,16 +55,15 @@ function simulate(parameters, biomass; concentration::Vector{Float64}=rand(Float
     return minimum(integrator.u) < (100.0*eps())
   end
 
-  function remove_species!(integrator, parameters)
+  function remove_species!(integrator)
     for i in eachindex(integrator.u)
       integrator.u[i] = integrator.u[i] < 100.0*eps() ? 0.0 : integrator.u[i]
-      (integrator.u[i] < 100.0*eps()) .& (i ∉ parameters[:ε]) ? append!(parameters[:ε], i) : nothing
     end
   end
 
   function remove_species_and_rewire!(integrator)
     remove_species!(integrator)
-    parameters = update_rewiring_parameters(parameters, integrator.u)
+    parameters = update_rewiring_parameters(parameters, integrator.u, integrator.t)
   end
 
   affect_function = parameters[:rewire_method] == :none ? remove_species! : remove_species_and_rewire!

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -55,9 +55,10 @@ function simulate(parameters, biomass; concentration::Vector{Float64}=rand(Float
     return minimum(integrator.u) < (100.0*eps())
   end
 
-  function remove_species!(integrator)
+  function remove_species!(integrator, parameters)
     for i in eachindex(integrator.u)
       integrator.u[i] = integrator.u[i] < 100.0*eps() ? 0.0 : integrator.u[i]
+      (integrator.u[i] < 100.0*eps()) .& (i ∉ parameters[:ε]) ? append!(parameters[:ε], i) : nothing
     end
   end
 

--- a/test/make_parameters.jl
+++ b/test/make_parameters.jl
@@ -118,10 +118,6 @@ module TestMakeParameters
   @test pref_par[:preferenceMethod] == test_preferenceMethod
   @test pref_par[:specialistPrefMag] == test_specialistPrefMag
 
-      # empty extinction vector to store extinct species during simulations
-  right_extinctions = Int64[]
-  @test pref_par[:extinctions] == right_extinctions
-
       # jaccard similarity matrix
   network_1 = correct_network #all species have different resources
   pref_par_1 = BioEnergeticFoodWebs.preference_parameters(test_cost, test_specialistPrefMag, network_1, test_preferenceMethod)
@@ -187,7 +183,7 @@ module TestUpdateParameters
   RWmethod = :ADBM
   parameters = model_parameters(A, rewire_method = RWmethod)
   old_p = copy(parameters)
-  BioEnergeticFoodWebs.update_rewiring_parameters(parameters, b)
+  BioEnergeticFoodWebs.update_rewiring_parameters(parameters, b, 1)
 
   #check that all links from and to 3 are gone
   @test parameters[:A] == Int.(zero(A))
@@ -211,7 +207,7 @@ module TestUpdateParameters
   RWmethod = :Gilljam
   parameters = model_parameters(A, rewire_method = RWmethod)
   old_p = copy(parameters)
-  BioEnergeticFoodWebs.update_rewiring_parameters(parameters, b)
+  BioEnergeticFoodWebs.update_rewiring_parameters(parameters, b, 1)
 
   #check that all links from and to 3 are gone
   @test parameters[:A][:,3] ==  parameters[:A][3,:] == zeros(4)
@@ -237,7 +233,7 @@ module TestUpdateParameters
   RWmethod = :stan
   parameters = model_parameters(A, rewire_method = RWmethod)
   old_p = copy(parameters)
-  BioEnergeticFoodWebs.update_rewiring_parameters(parameters, b)
+  BioEnergeticFoodWebs.update_rewiring_parameters(parameters, b, 1)
   #no released prey => no new link
   @test parameters[:A][:,3] ==  parameters[:A][3,:] == zeros(4)
   # 1 is not an herbivore anymore (no resource)


### PR DESCRIPTION
This PR fixes the bug appearing when using `rewiring_method = :stan` or `: Gilljam`. It also improves / add extinctions tracking for all rewiring method by:
- adding extinction tracking for `:ADBM` 
- adding a new parameters to track the timestep at which extinctions happen (`p[:extinctionstime]`) 
- adding a new parameters to trak changes in the interaction matrix (`p[:tmpA]`)
