### PR TITLE
:ambulance: Fix temperature instabilities

### DIFF
--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -175,9 +175,9 @@ function dBdt(derivative, biomass, parameters::Dict{Symbol,Any}, t)
   dbdt = zeros(eltype(biomass), length(biomass))
   for i in eachindex(dbdt)
     balance = growth[i] + gain[i] - loss[i]
-    if p[:forceNaNto0]
+    if parameters[:forceNaNto0]
       dbdt[i] = !isnan(balance) ? balance : 0.0
-      p[:is_unstable] = isnan(balance) ? true : false
+      parameters[:is_unstable] = isnan(balance) ? true : false
     else
       dbdt[i] = balance
     end

--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -110,8 +110,8 @@ function model_parameters(A;
         growthrate::Function = NoEffectTemperature(:growth),
         dry_mass_293::Array{Float64, 1}=[0.0],
         TSR_type::Symbol = :no_response,
-        forceNaNto0::Bool = false,
-        is_unstable::Bool = false)
+        forceNaNto0::Bool = false
+        )
 
   check_food_web(A)
 
@@ -311,6 +311,8 @@ function model_parameters(A;
   parameters[:np] = sum(parameters[:is_producer])
   parameters[:ar] = attack_r
   parameters[:r] = r
+  parameters[:forceNaNto0] = forceNaNto0
+  parameters[:is_unstable] = false
 
 
   check_parameters(parameters)

--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -109,7 +109,9 @@ function model_parameters(A;
         metabolicrate::Function = NoEffectTemperature(:metabolism),
         growthrate::Function = NoEffectTemperature(:growth),
         dry_mass_293::Array{Float64, 1}=[0.0],
-        TSR_type::Symbol = :no_response)
+        TSR_type::Symbol = :no_response,
+        forceNaNto0::Bool = false,
+        is_unstable::Bool = false)
 
   check_food_web(A)
 


### PR DESCRIPTION
This is a **temporary** fix for #74  .

This PR introduce two new arguments to `make_parameters` that make is possible to deal with instabilities linked to certain parametrization of the thermal dependency of consumption rates. Given that instabilities seem to happen at low values (typically < 1e-10), these arguments offer the possibility to set `NaN` biomass values to `0.0`. To is *not* the default behaviour, to force it, `p[:forceNaNto0]` can be set to `true`. `p[:is_unstable]` (initially false) will then take the value `true` is `NaN` were detected during the simulations. 
