### PR TITLE
Zombie species

### DIFF
--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -166,10 +166,10 @@ function dBdt(derivative, biomass, parameters::Dict{Symbol,Any}, t)
   end
 
   # Consumption
-  gain, loss = consumption(parameters, biomass)
+  gain, loss = BioEnergeticFoodWebs.consumption(parameters, biomass)
 
   # Growth
-  growth, G = get_growth(parameters, biomass; c = nutrients)
+  growth, G = BioEnergeticFoodWebs.get_growth(parameters, biomass; c = nutrients)
 
   # Balance
   dbdt = zeros(eltype(biomass), length(biomass))
@@ -177,7 +177,7 @@ function dBdt(derivative, biomass, parameters::Dict{Symbol,Any}, t)
     dbdt[i] = growth[i] + gain[i] - loss[i]
   end
 
-  parameters[:productivity] == :nutrients && append!(dbdt, nutrientuptake(parameters, biomass, nutrients, G))
+  parameters[:productivity] == :nutrients && append!(dbdt, BioEnergeticFoodWebs.nutrientuptake(parameters, biomass, nutrients, G))
   for i in eachindex(dbdt)
     derivative[i] = dbdt[i]
   end

--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -166,10 +166,10 @@ function dBdt(derivative, biomass, parameters::Dict{Symbol,Any}, t)
   end
 
   # Consumption
-  gain, loss = BioEnergeticFoodWebs.consumption(parameters, biomass)
+  gain, loss = consumption(parameters, biomass)
 
   # Growth
-  growth, G = BioEnergeticFoodWebs.get_growth(parameters, biomass; c = nutrients)
+  growth, G = get_growth(parameters, biomass; c = nutrients)
 
   # Balance
   dbdt = zeros(eltype(biomass), length(biomass))
@@ -177,7 +177,7 @@ function dBdt(derivative, biomass, parameters::Dict{Symbol,Any}, t)
     dbdt[i] = growth[i] + gain[i] - loss[i]
   end
 
-  parameters[:productivity] == :nutrients && append!(dbdt, BioEnergeticFoodWebs.nutrientuptake(parameters, biomass, nutrients, G))
+  parameters[:productivity] == :nutrients && append!(dbdt, nutrientuptake(parameters, biomass, nutrients, G))
   for i in eachindex(dbdt)
     derivative[i] = dbdt[i]
   end

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -31,7 +31,7 @@ top-level keys:
 The array of biomasses has one row for each timestep, and one column for
 each species.
 """
-function simulate(parameters, biomass; concentration::Vector{Float64}=rand(Float64, 2).*10, start::Int64=0, stop::Int64=500, use::Symbol=:nonstiff)
+function simulate(parameters, biomass; concentration::Vector{Float64}=rand(Float64, 2).*10, start::Int64=0, stop::Int64=500, use::Symbol=:nonstiff, cb_interp_points::Int64=100, extinction_threshold::Float64=100*eps())
   @assert stop > start
   @assert length(biomass) == size(parameters[:A],1)
   @assert length(concentration) == 2
@@ -54,45 +54,57 @@ function simulate(parameters, biomass; concentration::Vector{Float64}=rand(Float
   ϵ = []
 
   function species_under_extinction_threshold_nutrients(u, t, integrator)
-    working_biomass = integrator.u[1:end-2]
-    return minimum(working_biomass)
+    workingbm = deepcopy(integrator.u[1:end-2])
+    sort!(ϵ)
+    deleteat!(workingbm, unique(ϵ))
+    #cond = any(x -> x < 100*eps(), workingbm) ? 0.0 : 1.0
+    cond = any(x -> x < extinction_threshold, workingbm) ? 0.0 : 1.0
+    return cond
   end
 
   function species_under_extinction_threshold(u, t, integrator)
     workingbm = deepcopy(u)
-    deleteat!(workingbm, ϵ)
-    #println(minimum(workingbm))
-    cond = any(x -> x < 100*eps(), workingbm) ? 0.0 : 1.0
+    sort!(ϵ)
+    deleteat!(workingbm, unique(ϵ))
+    #cond = any(x -> x < 100*eps(), workingbm) ? 0.0 : 1.0
+    cond = any(x -> x < extinction_threshold, workingbm) ? -0.0 : 1.0
     return cond
   end
 
   function remove_species!(integrator)
     println(integrator.t)
     u = integrator.u
-    workingbm = deepcopy(u)
-    deleteat!(workingbm, ϵ)
-    idϵ = findall(x -> x < 100*eps(), workingbm)
-    append!(ϵ,idϵ)
-    u[idϵ] .= 0.0
-    # for i in eachindex(u)
-    #   u[i] = u[i] < 1e-10 ? 0.0 : u[i]
-    # end
+    #workingbm = deepcopy(u)
+    #idϵ = findall(x -> x < 100*eps(), workingbm)
+    idϵ = findall(x -> x < extinction_threshold, u)
+    for e in idϵ
+        if !(e ∈ ϵ)
+            u[e] = 0.0
+            append!(ϵ,e)
+        end
+    end
+    sort!(ϵ)
+    # deleteat!(workingbm, unique(ϵ))
+    # append!(ϵ,idϵ)
+    # u[idϵ] .= 0.0
     nothing
   end
 
   function remove_species_and_rewire!(integrator)
     remove_species!(integrator)
     if parameters[:productivity] == :nutrients
-      working_biomass = integrator.u[1:end-2]
+      workingbm = deepcopy(integrator.u[1:end-2])
     else
-      working_biomass = integrator.u
+      workingbm = deepcopy(integrator.u)
     end
-    parameters = update_rewiring_parameters(parameters, working_biomass, integrator.t)
+    parameters = update_rewiring_parameters(parameters, workingbm, integrator.t)
   end
 
   cb = parameters[:productivity] == :nutrients ? species_under_extinction_threshold_nutrients : species_under_extinction_threshold
   affect_function = parameters[:rewire_method] == :none ? remove_species! : remove_species_and_rewire!
-  extinction_callback = ContinuousCallback(species_under_extinction_threshold, remove_species!, abstol = eps())
+  extinction_callback = ContinuousCallback(cb, affect_function, abstol = 1e-6, interp_points = cb_interp_points)
+  #justincase_callback = PeriodicCallback(affect_function, periodic_check)
+  #CBset =  CallbackSet(extinction_callback, justincase_callback)
 
   sol = solve(prob, alg, callback = extinction_callback, saveat=t_keep, dense=false, save_timeseries=false, force_dtmin=false)
 


### PR DESCRIPTION
Fixes #77 

This PR changes the Callback conditions in the `simulate` function to better detect extinctions. It also introduces the possibility to control the extinction threshold and the number of interpolated points through the following keywords: 
- `extinction_threshold` (default to `1e-6`) 
- `cb_interp_points` (default to `100`)