### PR TITLE
Avoid DomainError when hill exponent is 1<h<2

### DIFF
--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -76,7 +76,8 @@ end
 
 function fill_bm_matrix!(bm_matrix::Matrix{Float64}, biomass::Vector{Float64}, w::Matrix{Float64}, A::Matrix{Int64}, h::Float64; rewire::Bool=false, costMat=nothing)
   for i in eachindex(biomass), j in eachindex(biomass)
-    @inbounds bm_matrix[i,j] = w[i,j] * (biomass[j] .^ h) * A[i,j]
+    workingbm = isapprox(biomass[j], 0, atol = 1e-5) ? 0.0 : deepcopy(biomass[j])
+    @inbounds bm_matrix[i,j] = w[i,j] * (workingbm[j] .^ h) * A[i,j]
     if rewire
       bm_matrix[i,j] *= costMat[i,j]
     end


### PR DESCRIPTION
Fixes #76 

Locally set `biomass = 0.0` when it's approx. `0.0` (abs. tolerance = `1e-5`) to avoid negative exponentiation.    