### PR TITLE
Temperature instabilities

### DIFF
--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -155,7 +155,6 @@ timepoint `t`, an array of biomasses `biomass`, and a series of simulation
 parameters `p`, it will return `dB/dt` for every species.
 """
 function dBdt(derivative, biomass, parameters::Dict{Symbol,Any}, t)
-  println(biomass)
   S = size(parameters[:A], 1)
 
   # producer growth if NP model

--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -155,6 +155,7 @@ timepoint `t`, an array of biomasses `biomass`, and a series of simulation
 parameters `p`, it will return `dB/dt` for every species.
 """
 function dBdt(derivative, biomass, parameters::Dict{Symbol,Any}, t)
+  println(biomass)
   S = size(parameters[:A], 1)
 
   # producer growth if NP model

--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -180,7 +180,7 @@ function dBdt(derivative, biomass, parameters::Dict{Symbol,Any}, t)
 
   parameters[:productivity] == :nutrients && append!(dbdt, nutrientuptake(parameters, biomass, nutrients, G))
   for i in eachindex(dbdt)
-    derivative[i] = sign(dbdt[i]) == 1.0 ? dbdt[i] : 0.0 #this test is necessary even with the callback in place for the very steep changes
+    derivative[i] = dbdt[i] #this test is necessary even with the callback in place for the very steep changes
   end
   return dbdt
 end

--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -181,7 +181,7 @@ function dBdt(derivative, biomass, parameters::Dict{Symbol,Any}, t)
 
   parameters[:productivity] == :nutrients && append!(dbdt, nutrientuptake(parameters, biomass, nutrients, G))
   for i in eachindex(dbdt)
-    derivative[i] = dbdt[i]
+    derivative[i] = sign(dbdt[i]) == 1.0 ? dbdt[i] : 0.0 #this test is necessary even with the callback in place for the very steep changes
   end
   return dbdt
 end

--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -108,7 +108,7 @@ function model_parameters(A;
         attackrate::Function = NoEffectTemperature(:attackrate),
         metabolicrate::Function = NoEffectTemperature(:metabolism),
         growthrate::Function = NoEffectTemperature(:growth),
-        scale_maxcons::Bool = false,
+        scale_biological_rates::Bool = false,
         dry_mass_293::Array{Float64, 1}=[0.0],
         TSR_type::Symbol = :no_response)
 
@@ -279,12 +279,12 @@ function model_parameters(A;
   r = growthrate(parameters[:bodymass], T, parameters)
   rspp = r[sortperm(parameters[:bodymass])[1]]
   r_scaled = r ./ rspp
-  parameters[:r] = r_scaled
+  parameters[:r] = scale_biological_rates ? r_scaled : r
 
   # Step 13 -- Metabolic rate
   x = metabolicrate(parameters[:bodymass], T, parameters)
   x_scaled = x ./ rspp
-  parameters[:x] = x_scaled
+  parameters[:x] = scale_biological_rates ? x_scaled : x
 
   # Step 14 -- Handling time
   handling_t = handlingtime(parameters[:bodymass], T, parameters)
@@ -292,7 +292,7 @@ function model_parameters(A;
 
   # Step 16 -- Maximum relative consumption rate
   y = 1 ./ handling_t
-  parameters[:y] = scale_maxcons == true ? y ./ x : y
+  parameters[:y] = scale_biological_rates == true ? y ./ x : y
 
   # Step 15 -- Attack rate
   attack_r = attackrate(parameters[:bodymass], T, parameters)
@@ -307,7 +307,6 @@ function model_parameters(A;
 
   # Final Step -- store the parameters in the dict. p
   #parameters[:efficiency] = efficiency
-  parameters[:y] = y
   #parameters[:a] = a
   #parameters[:is_herbivore] = is_herbivore
   parameters[:Γh] = parameters[:Γ] .^ parameters[:h]

--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -108,7 +108,9 @@ function model_parameters(A;
         attackrate::Function = NoEffectTemperature(:attackrate),
         metabolicrate::Function = NoEffectTemperature(:metabolism),
         growthrate::Function = NoEffectTemperature(:growth),
-        scale_biological_rates::Bool = false,
+        scale_growth::Bool = false,
+        scale_metabolism::Bool = false,
+        scale_maxcons::Bool = false,
         dry_mass_293::Array{Float64, 1}=[0.0],
         TSR_type::Symbol = :no_response)
 
@@ -279,12 +281,12 @@ function model_parameters(A;
   r = growthrate(parameters[:bodymass], T, parameters)
   rspp = r[sortperm(parameters[:bodymass])[1]]
   r_scaled = r ./ rspp
-  parameters[:r] = scale_biological_rates ? r_scaled : r
+  parameters[:r] = scale_growth ? r_scaled : r
 
   # Step 13 -- Metabolic rate
   x = metabolicrate(parameters[:bodymass], T, parameters)
   x_scaled = x ./ rspp
-  parameters[:x] = scale_biological_rates ? x_scaled : x
+  parameters[:x] = scale_metabolism ? x_scaled : x
 
   # Step 14 -- Handling time
   handling_t = handlingtime(parameters[:bodymass], T, parameters)
@@ -292,7 +294,7 @@ function model_parameters(A;
 
   # Step 16 -- Maximum relative consumption rate
   y = 1 ./ handling_t
-  parameters[:y] = scale_biological_rates == true ? y ./ x : y
+  parameters[:y] = scale_maxcons == true ? y ./ x : y
 
   # Step 15 -- Attack rate
   attack_r = attackrate(parameters[:bodymass], T, parameters)

--- a/test/biological_rates.jl
+++ b/test/biological_rates.jl
@@ -56,7 +56,7 @@ module TestDefault
   @test p[:Γ] == [0.8, 0.8, 0.0]
 
   # NORMALISATION
-  p = model_parameters(food_chain, vertebrates = metab_status,
+  p_norm = model_parameters(food_chain, vertebrates = metab_status,
                        handlingtime = NoEffectTemperature(:handlingtime, parameters_tuple = (y_vertebrate = 3.0, y_invertebrate = 7.0)),
                        attackrate = NoEffectTemperature(:attackrate, parameters_tuple = (Γ = 0.8,)),
                        metabolicrate = NoEffectTemperature(:metabolism, parameters_tuple = (a_vertebrate = 0.8, a_invertebrate = 0.3, a_producer = 0.1)),
@@ -65,17 +65,17 @@ module TestDefault
                        scale_maxcons = true,
                        scale_metabolism = true)
   rspp = 2.0
-  @test p[:r] == [2.0, 2.0, 2.0] ./ rspp
+  @test p_norm[:r] == [2.0, 2.0, 2.0] ./ rspp
   # metabolic rates
-  @test p[:x] == [a_vertebrate, a_invertebrate, a_producer] ./ rspp
+  @test p_norm[:x] == [a_vertebrate, a_invertebrate, a_producer] ./ rspp
   # maximum consumption rate
-  @test p[:y] == [y_vertebrate, y_invertebrate, y_producer] ./ [a_vertebrate, a_invertebrate, a_producer]
+  @test p_norm[:y] == [y_vertebrate, y_invertebrate, y_producer] ./ [a_vertebrate, a_invertebrate, a_producer]
   # handling time
   # attack rate
-  @test p[:ar] == 1 ./ (0.8 * p[:ht])
+  @test p_norm[:ar] == 1 ./ (0.8 * p[:ht])
   # half saturation constant
-  @test p[:Γ] == hsc
-  @test p[:Γ] == [0.8, 0.8, 0.0]
+  @test p_norm[:Γ] == hsc
+  @test p_norm[:Γ] == [0.8, 0.8, 0.0]
 
   # Different temperatures, same rates
   temp2 = 293.15

--- a/test/biological_rates.jl
+++ b/test/biological_rates.jl
@@ -55,6 +55,28 @@ module TestDefault
   @test p[:Γ] == hsc
   @test p[:Γ] == [0.8, 0.8, 0.0]
 
+  # NORMALISATION
+  p = model_parameters(food_chain, vertebrates = metab_status,
+                       handlingtime = NoEffectTemperature(:handlingtime, parameters_tuple = (y_vertebrate = 3.0, y_invertebrate = 7.0)),
+                       attackrate = NoEffectTemperature(:attackrate, parameters_tuple = (Γ = 0.8,)),
+                       metabolicrate = NoEffectTemperature(:metabolism, parameters_tuple = (a_vertebrate = 0.8, a_invertebrate = 0.3, a_producer = 0.1)),
+                       growthrate = NoEffectTemperature(:growth, parameters_tuple = (r = 2.0,)),
+                       scale_growth = true,
+                       scale_maxcons = true,
+                       scale_metabolism = true)
+  rspp = 2.0
+  @test p[:r] == [2.0, 2.0, 2.0] ./ rspp
+  # metabolic rates
+  @test p[:x] == [a_vertebrate, a_invertebrate, a_producer] ./ rspp
+  # maximum consumption rate
+  @test p[:y] == [y_vertebrate, y_invertebrate, y_producer] ./ [a_vertebrate, a_invertebrate, a_producer]
+  # handling time
+  # attack rate
+  @test p[:ar] == 1 ./ (0.8 * p[:ht])
+  # half saturation constant
+  @test p[:Γ] == hsc
+  @test p[:Γ] == [0.8, 0.8, 0.0]
+
   # Different temperatures, same rates
   temp2 = 293.15
   p2 = model_parameters(food_chain, T = temp2, vertebrates = metab_status,

--- a/test/rewiring/ADBM.jl
+++ b/test/rewiring/ADBM.jl
@@ -74,7 +74,7 @@ module TestADBM_power
 
 end
 
-module TestADBM_power
+module TestADBM_power_ratio
     using BioEnergeticFoodWebs
     using Test
 


### PR DESCRIPTION
This PR introduces a new way of scaling the biological rates through the `model_parameters` function's keyword
- `scale_growth` : (default to `false`) if set to `true`, normalize growth rates by the growth rate of the smallest producer 
- `scale_metabolism` : (default to `false`) if set to `true`, normalize metabolic rates by the growth rate of the smallest producer 
- `scale_maxcons` : (default to `false`) if set to `true`, normalize maximum consumption rates by the metabolis rates
This should stabilize systems with temperature dependence (#74)