### PR TITLE
Density dependent mortality for consumers

### DIFF
--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -147,6 +147,10 @@ function consumption(parameters, biomass)
 
 end
 
+function density_dependent_mortality(parameters, biomass)
+  mortality = parameters[:d] .* biomass
+end
+
 """
 **Derivatives**
 
@@ -172,10 +176,13 @@ function dBdt(derivative, biomass, parameters::Dict{Symbol,Any}, t)
   # Growth
   growth, G = BioEnergeticFoodWebs.get_growth(parameters, biomass; c = nutrients)
 
+  # Mortality
+  mortality = BioEnergeticFoodWebs.density_dependent_mortality(parameters, biomass)
+
   # Balance
   dbdt = zeros(eltype(biomass), length(biomass))
   for i in eachindex(dbdt)
-    dbdt[i] = growth[i] + gain[i] - loss[i]
+    dbdt[i] = growth[i] + gain[i] - loss[i] - mortality[i]
   end
 
   parameters[:productivity] == :nutrients && append!(dbdt, BioEnergeticFoodWebs.nutrientuptake(parameters, biomass, nutrients, G))

--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -148,7 +148,7 @@ function consumption(parameters, biomass)
 end
 
 function density_dependent_mortality(parameters, biomass)
-  mortality = parameters[:d] .* biomass
+  mortality = parameters[:d](biomass) .* Int.(.!parameters[:is_producer])
 end
 
 """

--- a/src/dBdt.jl
+++ b/src/dBdt.jl
@@ -148,7 +148,9 @@ function consumption(parameters, biomass)
 end
 
 function density_dependent_mortality(parameters, biomass)
-  mortality = parameters[:d](biomass) .* Int.(.!parameters[:is_producer])
+  mortality_c = parameters[:dc](biomass) .* Int.(.!parameters[:is_producer])
+  mortality_p = parameters[:dp](biomass) .* Int.(parameters[:is_producer])
+  mortality = mortality_c .+ mortality_p
 end
 
 """

--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -335,7 +335,7 @@ function model_parameters(A;
       parameters[:d] = d
     end
   else
-    parameters[:d] = d .* Int.(parameters[:is_producer])
+    parameters[:d] = d .* Int.(.!parameters[:is_producer])
   end
 
   check_parameters(parameters)

--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -26,7 +26,7 @@ matrix A. See documentation for more information. Specifically, the default valu
 | scale_metabolism  | false         | whether to normalize metabolic rates by the growth rate of the smallest producer            |
 | scale_maxcons     | false         | whether to normalize max. consumption rates by metabolic rates                              |
 | productivity      | :species      | type of productivity regulation                                                             |
-| d                 | 0.0           | strength of density dependent mortality for consumers                                       |
+| d                 | x -> x .* 0.0 | density dependent mortality function for consumers                                          |
 | rewire_method     | :none         | method for rewiring the foodweb following extinction events                                 |
 | adbm_trigger      | :extinction   | (ADBM) trigger for ADBM rewiring (on extinctions or periodic with :interval)                |
 | adbm_interval     | 100           | (ADBM) Δt for periodic rewiring                                                             |
@@ -108,7 +108,7 @@ function model_parameters(A;
         bodymass::Array{Float64, 1}=[0.0],
         scale_bodymass::Bool=true,
         vertebrates::Array{Bool, 1}=[false],
-        d::Array{Float64, 1}=[0.0],
+        d::Function= (x -> x .* 0.0),
         rewire_method::Symbol = :none,
         adbm_trigger::Symbol = :extinction,
         adbm_interval::Int64 = 100,
@@ -328,15 +328,7 @@ function model_parameters(A;
   parameters[:ar] = attack_r
 
   # Step  19 -- Density dependent mortality
-  if length(d) > 1
-    if length(d) != size(A, 1)
-      error("when calling `model_parameters` with an array of values for `d`, there must be as many elements as rows/columns in the matrix")
-    else
-      parameters[:d] = d
-    end
-  else
-    parameters[:d] = d .* Int.(.!parameters[:is_producer])
-  end
+  parameters[:d] = d
 
   check_parameters(parameters)
 

--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -26,6 +26,7 @@ matrix A. See documentation for more information. Specifically, the default valu
 | scale_metabolism  | false         | whether to normalize metabolic rates by the growth rate of the smallest producer            |
 | scale_maxcons     | false         | whether to normalize max. consumption rates by metabolic rates                              |
 | productivity      | :species      | type of productivity regulation                                                             |
+| d                 | 0.0           | strength of density dependent mortality for consumers                                       |
 | rewire_method     | :none         | method for rewiring the foodweb following extinction events                                 |
 | adbm_trigger      | :extinction   | (ADBM) trigger for ADBM rewiring (on extinctions or periodic with :interval)                |
 | adbm_interval     | 100           | (ADBM) Δt for periodic rewiring                                                             |
@@ -107,6 +108,7 @@ function model_parameters(A;
         bodymass::Array{Float64, 1}=[0.0],
         scale_bodymass::Bool=true,
         vertebrates::Array{Bool, 1}=[false],
+        d::Int64=[0.0],
         rewire_method::Symbol = :none,
         adbm_trigger::Symbol = :extinction,
         adbm_interval::Int64 = 100,
@@ -321,10 +323,20 @@ function model_parameters(A;
   # Step 18 -- Efficiency matrix
   get_efficiency(parameters)
 
-  # Final Step -- store the parameters in the dict. p
   parameters[:Γh] = parameters[:Γ] .^ parameters[:h]
   parameters[:np] = sum(parameters[:is_producer])
   parameters[:ar] = attack_r
+
+  # Step  19 -- Density dependent mortality
+  if length(d) > 1
+    if length(d) != size(A, 1)
+      error("when calling `model_parameters` with an array of values for `d`, there must be as many elements as rows/columns in the matrix")
+    else
+      parameters[:d] = d
+    end
+  else
+    parameters[:d] = d .* Int.(parameters[:is_producer])
+  end
 
   check_parameters(parameters)
 

--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -108,7 +108,7 @@ function model_parameters(A;
         bodymass::Array{Float64, 1}=[0.0],
         scale_bodymass::Bool=true,
         vertebrates::Array{Bool, 1}=[false],
-        d::Int64=[0.0],
+        d::Array{Float64, 1}=[0.0],
         rewire_method::Symbol = :none,
         adbm_trigger::Symbol = :extinction,
         adbm_interval::Int64 = 100,

--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -110,7 +110,7 @@ function model_parameters(A;
         scale_bodymass::Bool=true,
         vertebrates::Array{Bool, 1}=[false],
         dc::Function= (x -> x .* 0.0),
-        dr::Function= (x -> x .* 0.0),
+        dp::Function= (x -> x .* 0.0),
         rewire_method::Symbol = :none,
         adbm_trigger::Symbol = :extinction,
         adbm_interval::Int64 = 100,

--- a/src/make_parameters.jl
+++ b/src/make_parameters.jl
@@ -26,7 +26,8 @@ matrix A. See documentation for more information. Specifically, the default valu
 | scale_metabolism  | false         | whether to normalize metabolic rates by the growth rate of the smallest producer            |
 | scale_maxcons     | false         | whether to normalize max. consumption rates by metabolic rates                              |
 | productivity      | :species      | type of productivity regulation                                                             |
-| d                 | x -> x .* 0.0 | density dependent mortality function for consumers                                          |
+| dc                | x -> x .* 0.0 | density dependent mortality function for consumers                                          |
+| dp                | x -> x .* 0.0 | density dependent mortality function for producers                                          |
 | rewire_method     | :none         | method for rewiring the foodweb following extinction events                                 |
 | adbm_trigger      | :extinction   | (ADBM) trigger for ADBM rewiring (on extinctions or periodic with :interval)                |
 | adbm_interval     | 100           | (ADBM) Δt for periodic rewiring                                                             |
@@ -108,7 +109,8 @@ function model_parameters(A;
         bodymass::Array{Float64, 1}=[0.0],
         scale_bodymass::Bool=true,
         vertebrates::Array{Bool, 1}=[false],
-        d::Function= (x -> x .* 0.0),
+        dc::Function= (x -> x .* 0.0),
+        dr::Function= (x -> x .* 0.0),
         rewire_method::Symbol = :none,
         adbm_trigger::Symbol = :extinction,
         adbm_interval::Int64 = 100,
@@ -328,7 +330,8 @@ function model_parameters(A;
   parameters[:ar] = attack_r
 
   # Step  19 -- Density dependent mortality
-  parameters[:d] = d
+  parameters[:dc] = dc
+  parameters[:dp] = dp
 
   check_parameters(parameters)
 

--- a/test/mortality.jl
+++ b/test/mortality.jl
@@ -1,26 +1,29 @@
-using BioEnergeticFoodWebs
-using Test
+module TestDDMortality
+    using BioEnergeticFoodWebs
+    using Test
 
-A = [0 1 0 ; 0 0 1 ; 0 0 0]
-ddm = (x -> x .* 0.2)
-p = model_parameters(A, d = ddm)
+    A = [0 1 0 ; 0 0 1 ; 0 0 0]
+    ddm = (x -> x .* 0.2)
+    p = model_parameters(A, d = ddm)
 
-b = [0.5, 0.6, 0.8]
-PI_death = BioEnergeticFoodWebs.density_dependent_mortality(p, b)
-@test all(PI_death .== ddm(b) .* Int.(.!p[:is_producer]))
+    b = [0.5, 0.6, 0.8]
+    PI_death = BioEnergeticFoodWebs.density_dependent_mortality(p, b)
+    @test all(PI_death .== ddm(b) .* Int.(.!p[:is_producer]))
 
-dbdt = BioEnergeticFoodWebs.dBdt(zeros(3), b, p, 1)
+    dbdt = BioEnergeticFoodWebs.dBdt(zeros(3), b, p, 1)
 
-# Consumption
-gain, loss = BioEnergeticFoodWebs.consumption(p, b)
+    # Consumption
+    gain, loss = BioEnergeticFoodWebs.consumption(p, b)
 
-# Growth
-growth, G = BioEnergeticFoodWebs.get_growth(p, b)
+    # Growth
+    growth, G = BioEnergeticFoodWebs.get_growth(p, b)
 
-# Balance
-balance = zeros(eltype(b), length(b))
-for i in eachindex(balance)
-  balance[i] = growth[i] + gain[i] - loss[i] - PI_death[i]
+    # Balance
+    balance = zeros(eltype(b), length(b))
+    for i in eachindex(balance)
+      balance[i] = growth[i] + gain[i] - loss[i] - PI_death[i]
+    end
+
+    @test all(dbdt .== balance)
+
 end
-
-@test all(dbdt .== balance)

--- a/test/mortality.jl
+++ b/test/mortality.jl
@@ -23,7 +23,7 @@ module TestDDMortality
 
     @test all(dbdt .== balance)
 
-    ddm_prod = (x -> x^2 .* 0.1)
+    ddm_prod = (x -> x .^ 2 .* 0.1)
     p = model_parameters(A, dc = ddm, dp = ddm_prod)
     PI_death = BioEnergeticFoodWebs.density_dependent_mortality(p, b)
     mc = ddm(b).* Int.(.!p[:is_producer])

--- a/test/mortality.jl
+++ b/test/mortality.jl
@@ -4,20 +4,17 @@ module TestDDMortality
 
     A = [0 1 0 ; 0 0 1 ; 0 0 0]
     ddm = (x -> x .* 0.2)
-    p = model_parameters(A, d = ddm)
+    p = model_parameters(A, dc = ddm)
 
     b = [0.5, 0.6, 0.8]
     PI_death = BioEnergeticFoodWebs.density_dependent_mortality(p, b)
     @test all(PI_death .== ddm(b) .* Int.(.!p[:is_producer]))
 
     dbdt = BioEnergeticFoodWebs.dBdt(zeros(3), b, p, 1)
-
     # Consumption
     gain, loss = BioEnergeticFoodWebs.consumption(p, b)
-
     # Growth
     growth, G = BioEnergeticFoodWebs.get_growth(p, b)
-
     # Balance
     balance = zeros(eltype(b), length(b))
     for i in eachindex(balance)
@@ -25,5 +22,26 @@ module TestDDMortality
     end
 
     @test all(dbdt .== balance)
+
+    ddm_prod = (x -> x^2 .* 0.1)
+    p = model_parameters(A, dc = ddm, dp = ddm_prod)
+    PI_death = BioEnergeticFoodWebs.density_dependent_mortality(p, b)
+    mc = ddm(b).* Int.(.!p[:is_producer])
+    mp = ddm_prod(b).* Int.(p[:is_producer])
+    @test all(PI_death .== mc .+ mp)
+
+    dbdt = BioEnergeticFoodWebs.dBdt(zeros(3), b, p, 1)
+    # Consumption
+    gain, loss = BioEnergeticFoodWebs.consumption(p, b)
+    # Growth
+    growth, G = BioEnergeticFoodWebs.get_growth(p, b)
+    # Balance
+    balance = zeros(eltype(b), length(b))
+    for i in eachindex(balance)
+      balance[i] = growth[i] + gain[i] - loss[i] - PI_death[i]
+    end
+
+    @test all(dbdt .== balance)
+
 
 end

--- a/test/mortality.jl
+++ b/test/mortality.jl
@@ -1,0 +1,27 @@
+using BioEnergeticFoodWebs
+using Test
+
+A = [0 1 0 ; 0 0 1 ; 0 0 0]
+ddm = [0.2]
+p = model_parameters(A, d = ddm)
+
+@test all(p[:d] .== [0.2, 0.2, 0.0])
+b = [0.5, 0.6, 0.8]
+PI_death = BioEnergeticFoodWebs.density_dependent_mortality(p, b)
+@test all(PI_death .== b .* ddm .* Int.(.!p[:is_producer]))
+
+dbdt = BioEnergeticFoodWebs.dBdt(zeros(3), b, p, 1)
+
+# Consumption
+gain, loss = BioEnergeticFoodWebs.consumption(p, b)
+
+# Growth
+growth, G = BioEnergeticFoodWebs.get_growth(p, b)
+
+# Balance
+balance = zeros(eltype(b), length(b))
+for i in eachindex(balance)
+  balance[i] = growth[i] + gain[i] - loss[i] - PI_death[i]
+end
+
+@test all(dbdt .== balance)

--- a/test/mortality.jl
+++ b/test/mortality.jl
@@ -2,13 +2,12 @@ using BioEnergeticFoodWebs
 using Test
 
 A = [0 1 0 ; 0 0 1 ; 0 0 0]
-ddm = [0.2]
+ddm = (x -> x .* 0.2)
 p = model_parameters(A, d = ddm)
 
-@test all(p[:d] .== [0.2, 0.2, 0.0])
 b = [0.5, 0.6, 0.8]
 PI_death = BioEnergeticFoodWebs.density_dependent_mortality(p, b)
-@test all(PI_death .== b .* ddm .* Int.(.!p[:is_producer]))
+@test all(PI_death .== ddm(b) .* Int.(.!p[:is_producer]))
 
 dbdt = BioEnergeticFoodWebs.dBdt(zeros(3), b, p, 1)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,8 @@ test_files = [
     "biological_rates.jl",
     "temperature_size.jl",
     "productivity.jl",
-    "extinctions.jl"
+    "extinctions.jl",
+    "mortality.jl"
 ]
 
 test_n = 1


### PR DESCRIPTION
New feature: possibility to pass a function to `model_parameters` to set density dependent mortality for consumers (keyword `dc`) and producers (keyword `dp`). Default is no mortality. 
