### PR TITLE
Fix Compatibility between Julia 1.7.2 and JLD2 (Issue #131)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/site/
 gh_deploy
 scraps.jl
 Manifest.toml
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ docs/site/
 gh_deploy
 scraps.jl
 Manifest.toml
-.vscode/settings.json

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 DiffEqCallbacks = "2.13"
 Distributions = "0.24"
+JLD2 = "0.4"
 JSON = "0.21"
 OrdinaryDiffEq = "5.42"
 StatsBase = "0.33"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 DiffEqCallbacks = "2.13"
 Distributions = "0.24"
-JLD2 = "0.3"
 JSON = "0.21"
 OrdinaryDiffEq = "5.42"
 StatsBase = "0.33"

--- a/src/BioEnergeticFoodWebs.jl
+++ b/src/BioEnergeticFoodWebs.jl
@@ -3,7 +3,7 @@ module BioEnergeticFoodWebs
 using Distributions
 using OrdinaryDiffEq, DiffEqCallbacks
 using JSON
-using JLD2
+using JLD2: @save
 using StatsBase
 using Statistics
 using LinearAlgebra

--- a/test/measures.jl
+++ b/test/measures.jl
@@ -55,7 +55,7 @@ module TestSave
     using Test
     using BioEnergeticFoodWebs
     using LinearAlgebra
-    using JLD2
+    using JLD2: @save 
     using JSON
 
     A = [0 0 0 ; 0 0 0 ; 0 0 0]


### PR DESCRIPTION
Fixes #131.

**Summary of changes:**

1. Upgrade JLD2 to latest released version (v0.4.22)
2. Import JLD2 with `using JLD2: @save` to avoid name conflict with save functions (from BioEnergeticFoodWebs and JLD2), as only the macro `@save` from JLD2 is used by the package.
